### PR TITLE
Complete chipmunk wrapper

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -64,6 +64,8 @@ const cpp_sources = &[_][]const u8{
     "src/thelib/shape.cpp",
     "src/thelib/space.cpp",
     "src/thelib/vect.cpp",
+    "src/thelib/contact.cpp",
+    "src/thelib/arbiter.cpp",
     "src/natural_log/natural_log.cpp",
     "src/allo/c_allocator.cpp",
     "src/allo/random_allocation_registry.cpp",

--- a/src/allo/ctti/detail/algorithm.hpp
+++ b/src/allo/ctti/detail/algorithm.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <cstdint>
+#include <cstddef>
 
 /// Simple compile time utility functions
 
 namespace allo::ctti::detail {
 
-template <typename T, std::size_t N>
-constexpr const T *begin(const T (&array)[N])
+template <typename T, size_t N> constexpr const T *begin(const T (&array)[N])
 {
     return &array[0];
 }

--- a/src/bullet.cpp
+++ b/src/bullet.cpp
@@ -17,11 +17,6 @@ lib::vect_t bullet_t::position() const noexcept
     return physics::get_body(body).position();
 }
 
-lib::opt_t<void *> bullet_t::user_data() const noexcept
-{
-    return physics::get_user_data(body);
-}
-
 /// Do not use this constructor unless you know what you're doing
 bullet_t::bullet_t(const bullet_creation_options_t &options) noexcept
     : body(physics::create_body(game_id_e::Bullet,

--- a/src/bullet.hpp
+++ b/src/bullet.hpp
@@ -49,7 +49,12 @@ struct bullet_t
     physics::raw_poly_shape_t shape;
     /// Get the position of this bullet
     [[nodiscard]] lib::vect_t position() const noexcept;
-    [[nodiscard]] lib::opt_t<void *> user_data() const noexcept;
+
+    template <typename T>
+    [[nodiscard]] inline constexpr lib::opt_t<T *> user_data() const noexcept
+    {
+        return physics::get_user_data<T>(body);
+    }
 
     /// Do not use this constructor unless you know what you're doing
     explicit bullet_t(const bullet_creation_options_t &) noexcept;

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -12,6 +12,7 @@ constexpr size_t initial_reservation = 512;
 struct physics_user_data_t
 {
     cw::game_id_e id;
+    size_t typehash;
     void *user_data;
 };
 
@@ -81,7 +82,8 @@ void cleanup() noexcept
 }
 
 template <typename T>
-void generic_set_user_data_and_id(T &object, game_id_e id, void *data) noexcept
+void generic_set_user_data_and_id_raw(T &object, game_id_e id, void *data,
+                                      size_t typehash) noexcept
 {
     if (!user_data.has_value()) [[unlikely]] {
         LN_FATAL("attempt to set user data of physics body before physics "
@@ -91,6 +93,7 @@ void generic_set_user_data_and_id(T &object, game_id_e id, void *data) noexcept
 
     auto new_user_data = user_data.value().alloc_new(physics_user_data_t{
         .id = id,
+        .typehash = typehash,
         .user_data = data,
     });
 
@@ -109,30 +112,33 @@ void generic_set_user_data_and_id(T &object, game_id_e id, void *data) noexcept
     object.set_user_data(*reinterpret_cast<void **>(&unsafe_data));
 }
 
-void set_user_data_and_id(raw_body_t handle, game_id_e id, void *data) noexcept
+void set_user_data_and_id_raw(raw_body_t handle, game_id_e id, void *data,
+                              size_t typehash) noexcept
 {
-    generic_set_user_data_and_id(get_body(handle), id, data);
+    generic_set_user_data_and_id_raw(get_body(handle), id, data, typehash);
 }
 
-void set_user_data_and_id(raw_poly_shape_t handle, game_id_e id,
-                          void *data) noexcept
+void set_user_data_and_id_raw(raw_poly_shape_t handle, game_id_e id, void *data,
+                              size_t typehash) noexcept
 {
-    generic_set_user_data_and_id(*get_polygon_shape(handle).parent_cast(), id,
-                                 data);
+    generic_set_user_data_and_id_raw(*get_polygon_shape(handle).parent_cast(),
+                                     id, data, typehash);
 }
 
-void set_user_data_and_id(raw_segment_shape_t handle, game_id_e id,
-                          void *data) noexcept
+void set_user_data_and_id_raw(raw_segment_shape_t handle, game_id_e id,
+                              void *data, size_t typehash) noexcept
 {
-    generic_set_user_data_and_id(*get_segment_shape(handle).parent_cast(), id,
-                                 data);
+    generic_set_user_data_and_id_raw(*get_segment_shape(handle).parent_cast(),
+                                     id, data, typehash);
 }
 
 template <typename T>
 requires(
     std::is_same_v<T, lib::shape_t> ||
     std::is_same_v<
-        T, lib::body_t>) auto generic_get_user_data(const T &object) noexcept
+        T, lib::body_t>) auto generic_get_user_data_raw(const T &object,
+                                                        size_t
+                                                            typehash) noexcept
     -> lib::opt_t<void *>
 {
     {
@@ -147,10 +153,22 @@ requires(
             &object.userData);
     auto maybe_user_data = user_data.value().get(user_data_handle);
     if (maybe_user_data.okay()) {
-        return maybe_user_data.release().user_data;
+        auto data = maybe_user_data.release();
+        if (data.typehash != typehash) {
+            LN_FATAL_FMT(
+                "Attempt to get user data of a physics object but asked "
+                "for a different type than what was stored. Had {} but asked "
+                "for type with hash {}",
+                data.typehash, typehash);
+            std::abort();
+        }
+        return data.user_data;
     } else {
         LN_ERROR("Bad cast occurred in physics::get_user_data. Indicates "
                  "that the implementation of get_physics_id is unreliable.");
+#ifndef NDEBUG
+        std::abort();
+#endif
         return {};
     }
 }
@@ -160,28 +178,36 @@ lib::opt_t<game_id_e> get_id(raw_body_t handle) noexcept
     return get_id(get_body(handle));
 }
 
-lib::opt_t<void *> get_user_data(const raw_body_t handle) noexcept
+lib::opt_t<void *> get_user_data_raw(const raw_body_t handle,
+                                     size_t typehash) noexcept
 {
-    return generic_get_user_data(get_body(handle));
+    return generic_get_user_data_raw(get_body(handle), typehash);
 }
 
-lib::opt_t<void *> get_user_data(const lib::body_t &body) noexcept
+lib::opt_t<void *> get_user_data_raw(const lib::body_t &body,
+                                     size_t typehash) noexcept
 {
-    return generic_get_user_data(body);
+    return generic_get_user_data_raw(body, typehash);
 }
 
-lib::opt_t<void *> get_user_data(raw_poly_shape_t handle) noexcept
+lib::opt_t<void *> get_user_data_raw(raw_poly_shape_t handle,
+                                     size_t typehash) noexcept
 {
-    return generic_get_user_data(*get_polygon_shape(handle).parent_cast());
-}
-lib::opt_t<void *> get_user_data(raw_segment_shape_t handle) noexcept
-{
-    return generic_get_user_data(*get_segment_shape(handle).parent_cast());
+    return generic_get_user_data_raw(*get_polygon_shape(handle).parent_cast(),
+                                     typehash);
 }
 
-lib::opt_t<void *> get_user_data(const lib::shape_t &shape) noexcept
+lib::opt_t<void *> get_user_data_raw(raw_segment_shape_t handle,
+                                     size_t typehash) noexcept
 {
-    return generic_get_user_data(shape);
+    return generic_get_user_data_raw(*get_segment_shape(handle).parent_cast(),
+                                     typehash);
+}
+
+lib::opt_t<void *> get_user_data_raw(const lib::shape_t &shape,
+                                     size_t typehash) noexcept
+{
+    return generic_get_user_data_raw(shape, typehash);
 }
 
 auto generic_get_id = [](auto object) -> lib::opt_t<game_id_e> {

--- a/src/physics.cpp
+++ b/src/physics.cpp
@@ -280,38 +280,32 @@ get_handle_from_polygon_shape(const lib::poly_shape_t &shape) noexcept
     return res.release();
 }
 
-void add_collision_handler(const cpCollisionHandler &handler) noexcept
+std::variant<raw_poly_shape_t, raw_segment_shape_t>
+get_handle_from_shape(const lib::shape_t &shape) noexcept
 {
-    cpCollisionHandler *new_handler = cpSpaceAddCollisionHandler(
-        &space.value(), handler.typeA, handler.typeB);
-    if (handler.postSolveFunc)
-        new_handler->postSolveFunc = handler.postSolveFunc;
-    if (handler.preSolveFunc)
-        new_handler->preSolveFunc = handler.preSolveFunc;
-    if (handler.userData)
-        new_handler->userData = handler.userData;
-    if (handler.beginFunc)
-        new_handler->beginFunc = handler.beginFunc;
-    if (handler.separateFunc)
-        new_handler->separateFunc = handler.separateFunc;
+    switch (shape.klass->type) {
+    case CP_CIRCLE_SHAPE:
+        LN_FATAL("Circle shapes not implemented but a handle was requested for "
+                 "one, unable to return anything.");
+        std::abort();
+        break;
+    case CP_POLY_SHAPE:
+        return get_handle_from_polygon_shape(
+            *reinterpret_cast<const lib::poly_shape_t *>(&shape));
+        break;
+    case CP_SEGMENT_SHAPE:
+        return get_handle_from_segment_shape(
+            *reinterpret_cast<const lib::segment_shape_t *>(&shape));
+        break;
+    default:
+        LN_FATAL("unknown or unimplemented shape type passed to "
+                 "get_handle_from_shape");
+        std::abort();
+        break;
+    }
 }
 
-void add_collision_handler_wildcard(
-    const collision_handler_wildcard_options_t &options) noexcept
-{
-    cpCollisionHandler *new_handler = cpSpaceAddWildcardHandler(
-        &space.value(), (cpCollisionType)options.typeA);
-    if (options.postSolveFunc)
-        new_handler->postSolveFunc = options.postSolveFunc;
-    if (options.preSolveFunc)
-        new_handler->preSolveFunc = options.preSolveFunc;
-    if (options.userData)
-        new_handler->userData = options.userData;
-    if (options.beginFunc)
-        new_handler->beginFunc = options.beginFunc;
-    if (options.separateFunc)
-        new_handler->separateFunc = options.separateFunc;
-}
+lib::space_t &get_space() noexcept { return space.value(); }
 
 /// Move all physics objects and potentially call collision handlers
 void update(float timestep) noexcept { space.value().step(timestep); }

--- a/src/physics.hpp
+++ b/src/physics.hpp
@@ -6,7 +6,9 @@
 #include "thelib/body.hpp"
 #include "thelib/opt.hpp"
 #include "thelib/shape.hpp"
+#include "thelib/space.hpp"
 #include <cstddef>
+#include <variant>
 
 namespace cw::physics {
 
@@ -54,44 +56,11 @@ void cleanup() noexcept;
 /// Move all physics objects and potentially call collision handlers
 void update(float timestep) noexcept;
 
-/// Add a collision handler which triggers whenever a certain two kinds of shape
-/// collide.
-///
-/// beginFunc: function that gets called when two shapes of the given types
-/// *start* colliding. Returning false from this function will make it so that
-/// those two shapes dont generate collisions with each other for this
-/// collision. Once they separate, they may collide again, and beginFunc will be
-/// called again.
-///
-/// preSolveFunc: function that runs when two shapes overlap, but before they
-/// have been resolved to be in the correct locations. So if typeA is a wall and
-/// typeB is a ball, the ball will still be inside the wall when this function
-/// gets called. You can return false from this function to cancel the effects
-/// of the collision.
-///
-/// postSolveFunc: This is called after collision happens, so you'll get
-/// information about the normal of the collision and the contact points and all
-/// that good stuff. The ball would be outside of the wall at this point.
-///
-/// separateFunc: Function that gets called whenever two bodies stop colliding.
-/// According to chipmunk docs, it is guaranteed to always be called in even
-/// amounts with the beginFunc.
-void add_collision_handler(const cpCollisionHandler &handler) noexcept;
-
-struct collision_handler_wildcard_options_t
-{
-    const collision_type_e typeA;
-    cpCollisionBeginFunc beginFunc;
-    cpCollisionPreSolveFunc preSolveFunc;
-    cpCollisionPostSolveFunc postSolveFunc;
-    cpCollisionSeparateFunc separateFunc;
-    cpDataPointer userData;
-};
-
-/// Same as regular collision handler, but there is no typeB: instead, it
-/// provides handler calls whenever anything of typeA hits *anything* else.
-void add_collision_handler_wildcard(
-    const collision_handler_wildcard_options_t &options) noexcept;
+/// Get the global space, useful for adding collision handlers.
+/// NOTE: the reason I am allowing people to get the space instead of just
+/// having a collision handler function is because i dont want to have to
+/// propagate all the template arguments
+lib::space_t &get_space() noexcept;
 
 /// Create a physics body and return a handle to it.
 raw_body_t create_body(game_id_e id,
@@ -155,6 +124,9 @@ get_handle_from_segment_shape(const lib::segment_shape_t &) noexcept;
 /// physics functions like get_id.
 raw_poly_shape_t
 get_handle_from_polygon_shape(const lib::poly_shape_t &) noexcept;
+
+std::variant<raw_poly_shape_t, raw_segment_shape_t>
+get_handle_from_shape(const lib::shape_t &) noexcept;
 
 lib::body_t &get_body(raw_body_t) noexcept;
 lib::segment_shape_t &get_segment_shape(raw_segment_shape_t) noexcept;

--- a/src/physics_collision_types.hpp
+++ b/src/physics_collision_types.hpp
@@ -3,7 +3,7 @@
 
 namespace cw::physics {
 
-enum class collision_type_e : cpCollisionType
+enum collision_type_e : cpCollisionType
 {
     Player = 1,
     Ditch,

--- a/src/player.hpp
+++ b/src/player.hpp
@@ -11,7 +11,7 @@ struct player_t {
     public:
         void draw();
         void update();
-        static void collision_handler_static(cpArbiter *arb, cpSpace *space, cpDataPointer userData);
+        static void collision_handler_static(lib::arbiter_t& arb, lib::space_t &space, cpDataPointer userData);
 
         player_t() noexcept;
         ~player_t();

--- a/src/thelib/arbiter.cpp
+++ b/src/thelib/arbiter.cpp
@@ -1,0 +1,39 @@
+#include "arbiter.hpp"
+namespace lib {
+
+contact_t* arbiter_t::data() TESTING_NOEXCEPT {
+return reinterpret_cast<contact_t*>(reinterpret_cast<cpArbiter*>(this)->contacts);
+}
+
+    /// How far the objects overlapped before being resolved.
+    [[nodiscard]] float  arbiter_t::depth() const TESTING_NOEXCEPT {
+		
+	}
+    /// The normal of the collision between the given shapes.
+    [[nodiscard]] vect_t arbiter_t::normal() const TESTING_NOEXCEPT;
+    /// Get user data which only exists if set using set_user_data
+    /// The friction coefficient that will be applied to the pair of colliding
+    /// objects.
+    [[nodiscard]] float arbiter_t::friction() const TESTING_NOEXCEPT;
+    /// Calculate the total impulse including the friction that was applied by
+    /// this arbiter. This function should only be called from a post-solve,
+    /// post-step or cpBodyEachArbiter callback.
+    [[nodiscard]] vect_t arbiter_t::total_impulse() const TESTING_NOEXCEPT;
+	/// get the restitution AKA elasticity of the colliding objects
+    [[nodiscard]] float arbiter_t:: restitution() const TESTING_NOEXCEPT;
+    [[nodiscard]] vect_t arbiter_t::surface_velocity() const TESTING_NOEXCEPT;
+    /// Is true if the arbiter exists to handle the removal of a shape or body
+    /// from the space.
+    [[nodiscard]] bool arbiter_t::is_removal() const TESTING_NOEXCEPT;
+    // TODO: consider making count return unsigned?
+    /// The number of contact points for this arbiter
+    [[nodiscard]] int arbiter_t::count() const TESTING_NOEXCEPT;
+	/// returns true if this is the first step that a particular pair of objects
+	/// started colliding. ie. whether begin callback will be called.
+    [[nodiscard]] bool arbiter_t::is_first_contact() const TESTING_NOEXCEPT;
+    [[nodiscard]] vect_t arbiter_t::point_a() const TESTING_NOEXCEPT;
+    [[nodiscard]] vect_t arbiter_t::point_b() const TESTING_NOEXCEPT;
+    [[nodiscard]] vect_t arbiter_t::contact_point_set() const TESTING_NOEXCEPT;
+    [[nodiscard]] void * arbiter_t::user_data() const TESTING_NOEXCEPT;
+
+}

--- a/src/thelib/arbiter.cpp
+++ b/src/thelib/arbiter.cpp
@@ -1,39 +1,125 @@
 #include "arbiter.hpp"
 namespace lib {
 
-contact_t* arbiter_t::data() TESTING_NOEXCEPT {
-return reinterpret_cast<contact_t*>(reinterpret_cast<cpArbiter*>(this)->contacts);
+body_t &arbiter_t::body_a() const TESTING_NOEXCEPT
+{
+    return *body_t::from_chipmunk(static_cast<const cpArbiter *>(this)->body_a);
 }
 
-    /// How far the objects overlapped before being resolved.
-    [[nodiscard]] float  arbiter_t::depth() const TESTING_NOEXCEPT {
-		
-	}
-    /// The normal of the collision between the given shapes.
-    [[nodiscard]] vect_t arbiter_t::normal() const TESTING_NOEXCEPT;
-    /// Get user data which only exists if set using set_user_data
-    /// The friction coefficient that will be applied to the pair of colliding
-    /// objects.
-    [[nodiscard]] float arbiter_t::friction() const TESTING_NOEXCEPT;
-    /// Calculate the total impulse including the friction that was applied by
-    /// this arbiter. This function should only be called from a post-solve,
-    /// post-step or cpBodyEachArbiter callback.
-    [[nodiscard]] vect_t arbiter_t::total_impulse() const TESTING_NOEXCEPT;
-	/// get the restitution AKA elasticity of the colliding objects
-    [[nodiscard]] float arbiter_t:: restitution() const TESTING_NOEXCEPT;
-    [[nodiscard]] vect_t arbiter_t::surface_velocity() const TESTING_NOEXCEPT;
-    /// Is true if the arbiter exists to handle the removal of a shape or body
-    /// from the space.
-    [[nodiscard]] bool arbiter_t::is_removal() const TESTING_NOEXCEPT;
-    // TODO: consider making count return unsigned?
-    /// The number of contact points for this arbiter
-    [[nodiscard]] int arbiter_t::count() const TESTING_NOEXCEPT;
-	/// returns true if this is the first step that a particular pair of objects
-	/// started colliding. ie. whether begin callback will be called.
-    [[nodiscard]] bool arbiter_t::is_first_contact() const TESTING_NOEXCEPT;
-    [[nodiscard]] vect_t arbiter_t::point_a() const TESTING_NOEXCEPT;
-    [[nodiscard]] vect_t arbiter_t::point_b() const TESTING_NOEXCEPT;
-    [[nodiscard]] vect_t arbiter_t::contact_point_set() const TESTING_NOEXCEPT;
-    [[nodiscard]] void * arbiter_t::user_data() const TESTING_NOEXCEPT;
-
+body_t &arbiter_t::body_b() const TESTING_NOEXCEPT
+{
+    return *body_t::from_chipmunk(static_cast<const cpArbiter *>(this)->body_b);
 }
+
+shape_t &arbiter_t::shape_a() const TESTING_NOEXCEPT {
+    return *shape_t::from_chipmunk(static_cast<const cpArbiter *>(this)->a);
+}
+
+shape_t &arbiter_t::shape_b() const TESTING_NOEXCEPT;
+
+contact_t *arbiter_t::data() TESTING_NOEXCEPT
+{
+    return reinterpret_cast<contact_t *>(
+        reinterpret_cast<cpArbiter *>(this)->contacts);
+}
+
+opt_t<slice_t<contact_t>> arbiter_t::contacts() const TESTING_NOEXCEPT
+{
+    if (size() == 0)
+        return {};
+
+    return lib::raw_slice(
+        static_cast<contact_t &>(
+            static_cast<const cpArbiter *>(this)->contacts[0]),
+        size());
+}
+
+size_t arbiter_t::size() const TESTING_NOEXCEPT
+{
+    return cpArbiterGetCount(this);
+}
+
+float arbiter_t::depth(uint32_t index) const TESTING_NOEXCEPT
+{
+    return cpArbiterGetDepth(this, static_cast<int>(index));
+}
+float arbiter_t::depth(const contact_t &contact) const TESTING_NOEXCEPT
+{
+    auto *c = static_cast<const contact_t *>(
+        static_cast<const cpArbiter *>(this)->contacts);
+#ifndef NDEBUG
+    if (&contact > c) {
+        // NOTE: not checking if the contact is beyond the end of the arbiter's
+        // contacts, because chipmunk already does that for us in debug mode.
+        LN_FATAL(
+            "Attempt to get the depth of a contact which was not stored in "
+            "this arbiter.");
+        ABORT();
+    }
+#endif
+    uint32_t index = &contact - c;
+    assert(index < size());
+    return depth(index);
+}
+
+vect_t arbiter_t::normal() const TESTING_NOEXCEPT
+{
+    return cpArbiterGetNormal(this);
+}
+
+float arbiter_t::friction() const TESTING_NOEXCEPT
+{
+    return cpArbiterGetFriction(this);
+}
+
+vect_t arbiter_t::total_impulse() const TESTING_NOEXCEPT
+{
+    return cpArbiterTotalImpulse(this);
+}
+
+float arbiter_t::restitution() const TESTING_NOEXCEPT
+{
+    return cpArbiterGetRestitution(this);
+}
+
+vect_t arbiter_t::surface_velocity() TESTING_NOEXCEPT
+{
+    return cpArbiterGetSurfaceVelocity(this);
+}
+
+bool arbiter_t::is_removal() const TESTING_NOEXCEPT
+{
+    return cpArbiterIsRemoval(this);
+}
+
+bool arbiter_t::is_first_contact() const TESTING_NOEXCEPT
+{
+    return cpArbiterIsFirstContact(this);
+}
+
+void *arbiter_t::user_data() const TESTING_NOEXCEPT
+{
+    return cpArbiterGetUserData(this);
+}
+
+void arbiter_t::set_user_data(void *data) TESTING_NOEXCEPT
+{
+    cpArbiterSetUserData(this, data);
+}
+
+void arbiter_t::set_restitution(float res) TESTING_NOEXCEPT
+{
+    cpArbiterSetRestitution(this, res);
+}
+
+void arbiter_t::set_friction(float friction) TESTING_NOEXCEPT
+{
+    cpArbiterSetFriction(this, friction);
+}
+
+void arbiter_t::set_surface_velocity(vect_t vel) TESTING_NOEXCEPT
+{
+    cpArbiterSetSurfaceVelocity(this, vel);
+}
+
+} // namespace lib

--- a/src/thelib/arbiter.cpp
+++ b/src/thelib/arbiter.cpp
@@ -1,21 +1,39 @@
 #include "arbiter.hpp"
 namespace lib {
 
-body_t &arbiter_t::body_a() const TESTING_NOEXCEPT
+const body_t &arbiter_t::body_a_const() const TESTING_NOEXCEPT
 {
-    return *body_t::from_chipmunk(static_cast<const cpArbiter *>(this)->body_a);
+    return *body_t::from_chipmunk_const(
+        static_cast<const cpArbiter *>(this)->body_a);
 }
 
-body_t &arbiter_t::body_b() const TESTING_NOEXCEPT
+const body_t &arbiter_t::body_b_const() const TESTING_NOEXCEPT
 {
-    return *body_t::from_chipmunk(static_cast<const cpArbiter *>(this)->body_b);
+    return *body_t::from_chipmunk_const(
+        static_cast<const cpArbiter *>(this)->body_b);
 }
 
-shape_t &arbiter_t::shape_a() const TESTING_NOEXCEPT {
-    return *shape_t::from_chipmunk(static_cast<const cpArbiter *>(this)->a);
+const shape_t &arbiter_t::shape_a() const TESTING_NOEXCEPT
+{
+    return *shape_t::from_chipmunk_const(
+        static_cast<const cpArbiter *>(this)->a);
 }
 
-shape_t &arbiter_t::shape_b() const TESTING_NOEXCEPT;
+const shape_t &arbiter_t::shape_b() const TESTING_NOEXCEPT
+{
+    return *shape_t::from_chipmunk_const(
+        static_cast<const cpArbiter *>(this)->a);
+}
+
+body_t &arbiter_t::body_a() TESTING_NOEXCEPT
+{
+    return *body_t::from_chipmunk(static_cast<cpArbiter *>(this)->body_a);
+}
+
+body_t &arbiter_t::body_b() TESTING_NOEXCEPT
+{
+    return *body_t::from_chipmunk(static_cast<cpArbiter *>(this)->body_b);
+}
 
 contact_t *arbiter_t::data() TESTING_NOEXCEPT
 {

--- a/src/thelib/arbiter.hpp
+++ b/src/thelib/arbiter.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "body.hpp"
-#include "chipmunk/chipmunk_structs.h"
 #include "contact.hpp"
+#include "opt.hpp"
 #include "shape.hpp"
 #include "slice.hpp"
 
@@ -13,118 +13,68 @@ class arbiter_t : public ::cpArbiter
   public:
     arbiter_t() TESTING_NOEXCEPT;
 
+    [[nodiscard]] const body_t &body_a_const() const TESTING_NOEXCEPT;
+    [[nodiscard]] const body_t &body_b_const() const TESTING_NOEXCEPT;
+    [[nodiscard]] const shape_t &shape_a_const() const TESTING_NOEXCEPT;
+    [[nodiscard]] const shape_t &shape_b_const() const TESTING_NOEXCEPT;
+    [[nodiscard]] body_t &body_a() TESTING_NOEXCEPT;
+    [[nodiscard]] body_t &body_b() TESTING_NOEXCEPT;
+    [[nodiscard]] shape_t &shape_a() TESTING_NOEXCEPT;
+    [[nodiscard]] shape_t &shape_b() TESTING_NOEXCEPT;
+
     /// The buffer of memory containing contact points owned by this arbiter.
-    [[nodiscard]] slice_t<contact_t> contacts() const TESTING_NOEXCEPT;
+    /// Returns null if no contacts are present, ie. size() == 0.
+    [[nodiscard]] opt_t<slice_t<contact_t>> contacts() const TESTING_NOEXCEPT;
+
     /// The number of contacts owned by this arbiter.
     [[nodiscard]] size_t size() const TESTING_NOEXCEPT;
+
     /// Raw access to the contacts owned by thge arbiter. Prefer to use
     /// contacts() getter instead, if possible.
     [[nodiscard]] contact_t *data() TESTING_NOEXCEPT;
 
-    /// How far the objects overlapped before being resolved.
-    [[nodiscard]] float depth() const TESTING_NOEXCEPT;
+    /// How far the points overlapped before being resolved.
+    [[nodiscard]] float depth(uint32_t index) const TESTING_NOEXCEPT;
+
+    /// How far the points overlapped before being resolved.
+    [[nodiscard]] float depth(const contact_t &) const TESTING_NOEXCEPT;
+
     /// The normal of the collision between the given shapes.
     [[nodiscard]] vect_t normal() const TESTING_NOEXCEPT;
+
     /// Get user data which only exists if set using set_user_data
     /// The friction coefficient that will be applied to the pair of colliding
     /// objects.
     [[nodiscard]] float friction() const TESTING_NOEXCEPT;
+
     /// Calculate the total impulse including the friction that was applied by
     /// this arbiter. This function should only be called from a post-solve,
     /// post-step or cpBodyEachArbiter callback.
     [[nodiscard]] vect_t total_impulse() const TESTING_NOEXCEPT;
+
     /// get the restitution AKA elasticity of the colliding objects
     [[nodiscard]] float restitution() const TESTING_NOEXCEPT;
+
     /// Get the relative surface velocity of two shapes in contact
-    [[nodiscard]] vect_t surface_velocity() const TESTING_NOEXCEPT;
+    /// Not const for some reason? chipmunk why
+    [[nodiscard]] vect_t surface_velocity() TESTING_NOEXCEPT;
+
     /// Is true if the arbiter exists to handle the removal of a shape or body
     /// from the space.
     [[nodiscard]] bool is_removal() const TESTING_NOEXCEPT;
-    // TODO: consider making count return unsigned?
-    /// The number of contact points for this arbiter
-    [[nodiscard]] int count() const TESTING_NOEXCEPT;
+
     /// returns true if this is the first step that a particular pair of objects
     /// started colliding. ie. whether begin callback will be called.
     [[nodiscard]] bool is_first_contact() const TESTING_NOEXCEPT;
     [[nodiscard]] void *user_data() const TESTING_NOEXCEPT;
 
+    void set_user_data(void *) TESTING_NOEXCEPT;
+    void set_restitution(float) TESTING_NOEXCEPT;
+    void set_friction(float) TESTING_NOEXCEPT;
+    void set_surface_velocity(vect_t) TESTING_NOEXCEPT;
+
     // TODO: implement contact_point_set and get_contact_point set.
     // I don't think we'll need it for this game so I'm leaving it for now
     // [[nodiscard]] vect_t contact_point_set() const TESTING_NOEXCEPT;
-
-    struct iterator
-    {
-        using iterator_category = std::forward_iterator_tag;
-        using difference_type = std::ptrdiff_t;
-        using value_type = contact_t;
-        using pointer = contact_t *;
-        using reference = contact_t &;
-
-        inline constexpr iterator(arbiter_t &parent,
-                                  size_t index) TESTING_NOEXCEPT
-            : m_index(index),
-              m_parent(parent)
-        {
-        }
-
-        reference operator*() const TESTING_NOEXCEPT;
-
-        pointer operator->() TESTING_NOEXCEPT;
-
-        iterator &operator++() TESTING_NOEXCEPT;
-
-        const iterator operator++(int) TESTING_NOEXCEPT;
-
-        inline constexpr friend bool
-        operator==(const iterator &a, const iterator &b) TESTING_NOEXCEPT
-        {
-            // BUG: just checking if the memory location of the parents are the
-            // same. bad maybe?
-            return a.m_index == b.m_index && &a.m_parent == &b.m_parent;
-        };
-
-      private:
-        arbiter_t &m_parent;
-        size_t m_index;
-    };
-
-    struct const_iterator
-    {
-        using iterator_category = std::forward_iterator_tag;
-        using difference_type = std::ptrdiff_t;
-        using value_type = contact_t;
-        using pointer = const contact_t *;
-        using reference = const contact_t &;
-
-        inline constexpr const_iterator(const arbiter_t &parent,
-                                        size_t index) TESTING_NOEXCEPT
-            : m_index(index),
-              m_parent(parent)
-        {
-        }
-
-		[[nodiscard]] float depth() const TESTING_NOEXCEPT;
-
-        reference operator*() const TESTING_NOEXCEPT;
-
-        pointer operator->() TESTING_NOEXCEPT;
-
-        const_iterator &operator++() TESTING_NOEXCEPT;
-
-        const const_iterator operator++(int) TESTING_NOEXCEPT;
-
-        inline constexpr friend bool
-        operator==(const const_iterator &a,
-                   const const_iterator &b) TESTING_NOEXCEPT
-        {
-            // BUG: just checking if the memory location of the parents are the
-            // same. bad maybe?
-            return a.m_index == b.m_index && &a.m_parent == &b.m_parent;
-        };
-
-      private:
-        const arbiter_t &m_parent;
-        size_t m_index;
-    };
 };
 } // namespace lib

--- a/src/thelib/arbiter.hpp
+++ b/src/thelib/arbiter.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#include "chipmunk/chipmunk_structs.h"
+#include "thelib/body.hpp"
+#include "thelib/shape.hpp"
+
+namespace lib {
+/// An object which contains information about callbacks that need to be called
+/// for a particular collision of a given set of shapes.
+class arbiter_t : public ::cpArbiter
+{
+  public:
+    arbiter_t() TESTING_NOEXCEPT;
+
+    /// How far the objects overlapped before being resolved.
+    [[nodiscard]] float depth() const TESTING_NOEXCEPT;
+    /// The normal of the collision between the given shapes.
+    [[nodiscard]] vect_t normal() const TESTING_NOEXCEPT;
+    /// Get user data which only exists if set using set_user_data
+    [[nodiscard]] void *user_data() const TESTING_NOEXCEPT;
+    /// Get the relative surface velocity of two shapes in contact
+    [[nodiscard]] vect_t surface_velocity() const TESTING_NOEXCEPT;
+    /// Is true if the arbiter exists to handle the removal of a shape or body
+    /// from the space.
+    [[nodiscard]] bool is_removal() const TESTING_NOEXCEPT;
+    // TODO: consider making count return unsigned?
+    /// The number of contact points for this arbiter
+    [[nodiscard]] int count() const TESTING_NOEXCEPT;
+    /// The friction coefficient that will be applied to the pair of colliding
+    /// objects.
+    [[nodiscard]] float friction() const TESTING_NOEXCEPT;
+    /// Calculate the total impulse including the friction that was applied by
+    /// this arbiter. This function should only be called from a post-solve,
+    /// post-step or cpBodyEachArbiter callback.
+    [[nodiscard]] vect_t total_impulse() const TESTING_NOEXCEPT;
+	/// get the restitution AKA elasticity of the colliding objects
+    [[nodiscard]] float restitution() const TESTING_NOEXCEPT;
+	/// returns true if this is the first step that a particular pair of objects
+	/// started colliding. ie. whether begin callback will be called.
+    [[nodiscard]] bool is_first_contact() const TESTING_NOEXCEPT;
+	//
+    [[nodiscard]] vect_t point_a() const TESTING_NOEXCEPT;
+    [[nodiscard]] vect_t point_b() const TESTING_NOEXCEPT;
+    [[nodiscard]] vect_t contact_point_set() const TESTING_NOEXCEPT;
+};
+} // namespace lib

--- a/src/thelib/arbiter.hpp
+++ b/src/thelib/arbiter.hpp
@@ -1,7 +1,9 @@
 #pragma once
+#include "body.hpp"
 #include "chipmunk/chipmunk_structs.h"
-#include "thelib/body.hpp"
-#include "thelib/shape.hpp"
+#include "contact.hpp"
+#include "shape.hpp"
+#include "slice.hpp"
 
 namespace lib {
 /// An object which contains information about callbacks that need to be called
@@ -11,12 +13,28 @@ class arbiter_t : public ::cpArbiter
   public:
     arbiter_t() TESTING_NOEXCEPT;
 
+    /// The buffer of memory containing contact points owned by this arbiter.
+    [[nodiscard]] slice_t<contact_t> contacts() const TESTING_NOEXCEPT;
+    /// The number of contacts owned by this arbiter.
+    [[nodiscard]] size_t size() const TESTING_NOEXCEPT;
+    /// Raw access to the contacts owned by thge arbiter. Prefer to use
+    /// contacts() getter instead, if possible.
+    [[nodiscard]] contact_t *data() TESTING_NOEXCEPT;
+
     /// How far the objects overlapped before being resolved.
     [[nodiscard]] float depth() const TESTING_NOEXCEPT;
     /// The normal of the collision between the given shapes.
     [[nodiscard]] vect_t normal() const TESTING_NOEXCEPT;
     /// Get user data which only exists if set using set_user_data
-    [[nodiscard]] void *user_data() const TESTING_NOEXCEPT;
+    /// The friction coefficient that will be applied to the pair of colliding
+    /// objects.
+    [[nodiscard]] float friction() const TESTING_NOEXCEPT;
+    /// Calculate the total impulse including the friction that was applied by
+    /// this arbiter. This function should only be called from a post-solve,
+    /// post-step or cpBodyEachArbiter callback.
+    [[nodiscard]] vect_t total_impulse() const TESTING_NOEXCEPT;
+    /// get the restitution AKA elasticity of the colliding objects
+    [[nodiscard]] float restitution() const TESTING_NOEXCEPT;
     /// Get the relative surface velocity of two shapes in contact
     [[nodiscard]] vect_t surface_velocity() const TESTING_NOEXCEPT;
     /// Is true if the arbiter exists to handle the removal of a shape or body
@@ -25,21 +43,88 @@ class arbiter_t : public ::cpArbiter
     // TODO: consider making count return unsigned?
     /// The number of contact points for this arbiter
     [[nodiscard]] int count() const TESTING_NOEXCEPT;
-    /// The friction coefficient that will be applied to the pair of colliding
-    /// objects.
-    [[nodiscard]] float friction() const TESTING_NOEXCEPT;
-    /// Calculate the total impulse including the friction that was applied by
-    /// this arbiter. This function should only be called from a post-solve,
-    /// post-step or cpBodyEachArbiter callback.
-    [[nodiscard]] vect_t total_impulse() const TESTING_NOEXCEPT;
-	/// get the restitution AKA elasticity of the colliding objects
-    [[nodiscard]] float restitution() const TESTING_NOEXCEPT;
-	/// returns true if this is the first step that a particular pair of objects
-	/// started colliding. ie. whether begin callback will be called.
+    /// returns true if this is the first step that a particular pair of objects
+    /// started colliding. ie. whether begin callback will be called.
     [[nodiscard]] bool is_first_contact() const TESTING_NOEXCEPT;
-	//
-    [[nodiscard]] vect_t point_a() const TESTING_NOEXCEPT;
-    [[nodiscard]] vect_t point_b() const TESTING_NOEXCEPT;
-    [[nodiscard]] vect_t contact_point_set() const TESTING_NOEXCEPT;
+    [[nodiscard]] void *user_data() const TESTING_NOEXCEPT;
+
+    // TODO: implement contact_point_set and get_contact_point set.
+    // I don't think we'll need it for this game so I'm leaving it for now
+    // [[nodiscard]] vect_t contact_point_set() const TESTING_NOEXCEPT;
+
+    struct iterator
+    {
+        using iterator_category = std::forward_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = contact_t;
+        using pointer = contact_t *;
+        using reference = contact_t &;
+
+        inline constexpr iterator(arbiter_t &parent,
+                                  size_t index) TESTING_NOEXCEPT
+            : m_index(index),
+              m_parent(parent)
+        {
+        }
+
+        reference operator*() const TESTING_NOEXCEPT;
+
+        pointer operator->() TESTING_NOEXCEPT;
+
+        iterator &operator++() TESTING_NOEXCEPT;
+
+        const iterator operator++(int) TESTING_NOEXCEPT;
+
+        inline constexpr friend bool
+        operator==(const iterator &a, const iterator &b) TESTING_NOEXCEPT
+        {
+            // BUG: just checking if the memory location of the parents are the
+            // same. bad maybe?
+            return a.m_index == b.m_index && &a.m_parent == &b.m_parent;
+        };
+
+      private:
+        arbiter_t &m_parent;
+        size_t m_index;
+    };
+
+    struct const_iterator
+    {
+        using iterator_category = std::forward_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = contact_t;
+        using pointer = const contact_t *;
+        using reference = const contact_t &;
+
+        inline constexpr const_iterator(const arbiter_t &parent,
+                                        size_t index) TESTING_NOEXCEPT
+            : m_index(index),
+              m_parent(parent)
+        {
+        }
+
+		[[nodiscard]] float depth() const TESTING_NOEXCEPT;
+
+        reference operator*() const TESTING_NOEXCEPT;
+
+        pointer operator->() TESTING_NOEXCEPT;
+
+        const_iterator &operator++() TESTING_NOEXCEPT;
+
+        const const_iterator operator++(int) TESTING_NOEXCEPT;
+
+        inline constexpr friend bool
+        operator==(const const_iterator &a,
+                   const const_iterator &b) TESTING_NOEXCEPT
+        {
+            // BUG: just checking if the memory location of the parents are the
+            // same. bad maybe?
+            return a.m_index == b.m_index && &a.m_parent == &b.m_parent;
+        };
+
+      private:
+        const arbiter_t &m_parent;
+        size_t m_index;
+    };
 };
 } // namespace lib

--- a/src/thelib/arbiter.hpp
+++ b/src/thelib/arbiter.hpp
@@ -15,12 +15,10 @@ class arbiter_t : public ::cpArbiter
 
     [[nodiscard]] const body_t &body_a_const() const TESTING_NOEXCEPT;
     [[nodiscard]] const body_t &body_b_const() const TESTING_NOEXCEPT;
-    [[nodiscard]] const shape_t &shape_a_const() const TESTING_NOEXCEPT;
-    [[nodiscard]] const shape_t &shape_b_const() const TESTING_NOEXCEPT;
+    [[nodiscard]] const shape_t &shape_a() const TESTING_NOEXCEPT;
+    [[nodiscard]] const shape_t &shape_b() const TESTING_NOEXCEPT;
     [[nodiscard]] body_t &body_a() TESTING_NOEXCEPT;
     [[nodiscard]] body_t &body_b() TESTING_NOEXCEPT;
-    [[nodiscard]] shape_t &shape_a() TESTING_NOEXCEPT;
-    [[nodiscard]] shape_t &shape_b() TESTING_NOEXCEPT;
 
     /// The buffer of memory containing contact points owned by this arbiter.
     /// Returns null if no contacts are present, ie. size() == 0.

--- a/src/thelib/body.hpp
+++ b/src/thelib/body.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "chipmunk/chipmunk_structs.h"
-#include "thelib/shape.hpp"
-#include "thelib/vect.hpp"
+#include "shape.hpp"
+#include "vect.hpp"
 
 namespace lib {
 class body_t : public ::cpBody

--- a/src/thelib/body.hpp
+++ b/src/thelib/body.hpp
@@ -30,6 +30,12 @@ class body_t : public ::cpBody
         return reinterpret_cast<lib::body_t *>(body);
     }
 
+    static const lib::body_t *
+    from_chipmunk_const(const cpBody *body) TESTING_NOEXCEPT
+    {
+        return reinterpret_cast<const lib::body_t *>(body);
+    }
+
     explicit inline constexpr body_t(const cpBody &original) TESTING_NOEXCEPT
         : ::cpBody(original)
     {

--- a/src/thelib/collision_handler.hpp
+++ b/src/thelib/collision_handler.hpp
@@ -1,0 +1,62 @@
+#pragma once
+#include "arbiter.hpp"
+#include "chipmunk/chipmunk_types.h"
+#include "opt.hpp"
+
+namespace lib {
+class space_t;
+/// Collision begin event function callback type.
+/// Returning false from a begin callback causes the collision to be ignored
+/// until the the separate callback is called when the objects stop colliding.
+using collision_begin_func_t = bool (*)(arbiter_t &arb, space_t &space,
+                                        cpDataPointer userData);
+/// Collision pre-solve event function callback type.
+/// Returning false from a pre-step callback causes the collision to be ignored
+/// until the next step.
+using collision_pre_solve_func_t = bool (*)(arbiter_t &arb, space_t &space,
+                                            cpDataPointer userData);
+/// Collision post-solve event function callback type.
+using collision_post_solve_func_t = void (*)(arbiter_t &arb, space_t &space,
+                                             cpDataPointer userData);
+/// Collision separate event function callback type.
+using collision_separate_func_t = void (*)(arbiter_t &arb, space_t &space,
+                                           cpDataPointer userData);
+
+struct compile_time_collision_handler_info_t
+{
+    /// This function is called when two shapes with types that match this
+    /// collision handler begin colliding.
+    collision_begin_func_t begin_func;
+    /// This function is called each step when two shapes with types that match
+    /// this collision handler are colliding. It's called before the collision
+    /// solver runs so that you can affect a collision's outcome.
+    collision_pre_solve_func_t pre_solve_func;
+    /// This function is called each step when two shapes with types that match
+    /// this collision handler are colliding. It's called after the collision
+    /// solver runs so that you can read back information about the collision to
+    /// trigger events in your game.
+    collision_post_solve_func_t post_solve_func;
+    /// This function is called when two shapes with types that match this
+    /// collision handler stop colliding.
+    collision_separate_func_t separate_func;
+};
+
+template <compile_time_collision_handler_info_t comptime>
+struct collision_handler_t
+{
+    inline static constexpr compile_time_collision_handler_info_t functions =
+        comptime;
+    /// Collision type identifier of the first shape that this handler
+    /// recognizes. In the collision handler callback, the shape with this type
+    /// will be the first argument. Read only.
+    cpCollisionType type_a;
+    /// Collision type identifier of the second shape that this handler
+    /// recognizes. In the collision handler callback, the shape with this type
+    /// will be the second argument. If null, then *any* type will be matched
+    /// with the other type
+    opt_t<cpCollisionType> type_b;
+    /// This is a user definable context pointer that is passed to all of the
+    /// collision handler functions.
+    cpDataPointer user_data;
+};
+} // namespace lib

--- a/src/thelib/contact.cpp
+++ b/src/thelib/contact.cpp
@@ -1,0 +1,25 @@
+#include "contact.hpp"
+#include "arbiter.hpp"
+#include <cassert>
+
+namespace lib {
+vect_t contact_t::difference() const TESTING_NOEXCEPT
+{
+    // make sure subtract works cuz that broke once
+    assert(rel_point_one() - rel_point_two() ==
+           vect_t(cpvsub(rel_point_one(), rel_point_two())));
+    return rel_point_one() - rel_point_two();
+}
+
+std::pair<vect_t, vect_t> contact_t::points() const TESTING_NOEXCEPT
+{
+    return {};
+}
+
+vect_t contact_t::rel_point_one() const TESTING_NOEXCEPT {}
+vect_t contact_t::rel_point_two() const TESTING_NOEXCEPT {}
+vect_t contact_t::point_one(const arbiter_t &arb) const TESTING_NOEXCEPT {
+}
+/// Get the second point of contact in worldspace
+vect_t contact_t::point_two(const arbiter_t &arb) const TESTING_NOEXCEPT;
+} // namespace lib

--- a/src/thelib/contact.cpp
+++ b/src/thelib/contact.cpp
@@ -11,15 +11,44 @@ vect_t contact_t::difference() const TESTING_NOEXCEPT
     return rel_point_one() - rel_point_two();
 }
 
-std::pair<vect_t, vect_t> contact_t::points() const TESTING_NOEXCEPT
+std::pair<vect_t, vect_t> contact_t::rel_points() const TESTING_NOEXCEPT
 {
-    return {};
+    auto *c = static_cast<const cpContact *>(this);
+    return {c->r1, c->r2};
 }
 
-vect_t contact_t::rel_point_one() const TESTING_NOEXCEPT {}
-vect_t contact_t::rel_point_two() const TESTING_NOEXCEPT {}
-vect_t contact_t::point_one(const arbiter_t &arb) const TESTING_NOEXCEPT {
+std::pair<vect_t, vect_t>
+contact_t::points(const arbiter_t &arb) const TESTING_NOEXCEPT
+{
+    auto *chead = static_cast<const cpArbiter *>(&arb)->contacts;
+    assert(this > chead);
+    int index = static_cast<int>(static_cast<const cpContact *>(this) - chead);
+    return {cpArbiterGetPointA(&arb, index), cpArbiterGetPointB(&arb, index)};
 }
-/// Get the second point of contact in worldspace
-vect_t contact_t::point_two(const arbiter_t &arb) const TESTING_NOEXCEPT;
+
+vect_t contact_t::rel_point_one() const TESTING_NOEXCEPT
+{
+    return static_cast<const cpContact *>(this)->r1;
+}
+
+vect_t contact_t::rel_point_two() const TESTING_NOEXCEPT
+{
+    return static_cast<const cpContact *>(this)->r2;
+}
+
+vect_t contact_t::point_one(const arbiter_t &arb) const TESTING_NOEXCEPT
+{
+    auto *chead = static_cast<const cpArbiter *>(&arb)->contacts;
+    assert(this > chead);
+    int index = static_cast<int>(static_cast<const cpContact *>(this) - chead);
+    return cpArbiterGetPointA(&arb, index);
+}
+
+vect_t contact_t::point_two(const arbiter_t &arb) const TESTING_NOEXCEPT
+{
+    auto *chead = static_cast<const cpArbiter *>(&arb)->contacts;
+    assert(this > chead);
+    int index = static_cast<int>(static_cast<const cpContact *>(this) - chead);
+    return cpArbiterGetPointB(&arb, index);
+}
 } // namespace lib

--- a/src/thelib/contact.hpp
+++ b/src/thelib/contact.hpp
@@ -3,6 +3,7 @@
 #include "vect.hpp"
 
 namespace lib {
+class arbiter_t;
 /// Contains information about two relative points on two different bodies,
 /// where the bodies made contact.
 class contact_t : public ::cpContact
@@ -14,9 +15,13 @@ class contact_t : public ::cpContact
     /// coordinate space but it is relative to the collision (TODO: figure out
     /// what these are relative to lol)
     [[nodiscard]] std::pair<vect_t, vect_t> points() const TESTING_NOEXCEPT;
-	/// Get the first point of contact, NOT in worldspace
-    [[nodiscard]] vect_t point_one() const TESTING_NOEXCEPT;
-	/// Get the second point of contact, NOT in worldspace
-    [[nodiscard]] vect_t point_two() const TESTING_NOEXCEPT;
+    /// Get the first point of contact, NOT in worldspace
+    [[nodiscard]] vect_t rel_point_one() const TESTING_NOEXCEPT;
+    /// Get the second point of contact, NOT in worldspace
+    [[nodiscard]] vect_t rel_point_two() const TESTING_NOEXCEPT;
+    /// Get the first point of contact in worldspace
+    [[nodiscard]] vect_t point_one(const arbiter_t &arb) const TESTING_NOEXCEPT;
+    /// Get the second point of contact in worldspace
+    [[nodiscard]] vect_t point_two(const arbiter_t &arb) const TESTING_NOEXCEPT;
 };
 } // namespace lib

--- a/src/thelib/contact.hpp
+++ b/src/thelib/contact.hpp
@@ -12,9 +12,11 @@ class contact_t : public ::cpContact
     [[nodiscard]] vect_t difference() const TESTING_NOEXCEPT;
 
     /// Get the points of contact for both bodies. These are in the same
-    /// coordinate space but it is relative to the collision (TODO: figure out
-    /// what these are relative to lol)
-    [[nodiscard]] std::pair<vect_t, vect_t> points() const TESTING_NOEXCEPT;
+    /// coordinate space: relative to the collision.
+    [[nodiscard]] std::pair<vect_t, vect_t> rel_points() const TESTING_NOEXCEPT;
+    /// Get the points of contact for both bodies. These are both in worldspace
+    [[nodiscard]] std::pair<vect_t, vect_t>
+    points(const arbiter_t &arb) const TESTING_NOEXCEPT;
     /// Get the first point of contact, NOT in worldspace
     [[nodiscard]] vect_t rel_point_one() const TESTING_NOEXCEPT;
     /// Get the second point of contact, NOT in worldspace

--- a/src/thelib/contact.hpp
+++ b/src/thelib/contact.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include "chipmunk/chipmunk_structs.h"
+#include "vect.hpp"
+
+namespace lib {
+/// Contains information about two relative points on two different bodies,
+/// where the bodies made contact.
+class contact_t : public ::cpContact
+{
+    /// The difference between the two points relative 1 and relative 2.
+    [[nodiscard]] vect_t difference() const TESTING_NOEXCEPT;
+
+    /// Get the points of contact for both bodies. These are in the same
+    /// coordinate space but it is relative to the collision (TODO: figure out
+    /// what these are relative to lol)
+    [[nodiscard]] std::pair<vect_t, vect_t> points() const TESTING_NOEXCEPT;
+	/// Get the first point of contact, NOT in worldspace
+    [[nodiscard]] vect_t point_one() const TESTING_NOEXCEPT;
+	/// Get the second point of contact, NOT in worldspace
+    [[nodiscard]] vect_t point_two() const TESTING_NOEXCEPT;
+};
+} // namespace lib

--- a/src/thelib/rect.hpp
+++ b/src/thelib/rect.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "chipmunk/cpBB.h"
 #include "raylib.h"
-#include "thelib/vect.hpp"
+#include "vect.hpp"
 
 namespace lib {
 struct rect_t : public ::Rectangle

--- a/src/thelib/result.hpp
+++ b/src/thelib/result.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
+#include "result_errcode.hpp"
 #include "testing/abort.hpp"
-#include "thelib/result_errcode.hpp"
 #include <cstdint>
 #include <utility>
 #ifdef THELIB_RESULT_T_LOGGING

--- a/src/thelib/shape.cpp
+++ b/src/thelib/shape.cpp
@@ -1,5 +1,5 @@
-#include "thelib/shape.hpp"
-#include "thelib/body.hpp"
+#include "shape.hpp"
+#include "body.hpp"
 #include <cassert>
 
 #ifdef THELIB_DEBUG

--- a/src/thelib/shape.hpp
+++ b/src/thelib/shape.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include "chipmunk/chipmunk.h"
-#include "thelib/rect.hpp"
-#include "thelib/slice.hpp"
-#include "thelib/vect.hpp"
+#include "rect.hpp"
+#include "slice.hpp"
+#include "vect.hpp"
 #include <chipmunk/chipmunk_structs.h>
 
 namespace lib {

--- a/src/thelib/shape.hpp
+++ b/src/thelib/shape.hpp
@@ -21,6 +21,17 @@ class shape_t : public ::cpShape
     {
     }
 
+    static lib::shape_t *from_chipmunk(cpShape *body) TESTING_NOEXCEPT
+    {
+        return reinterpret_cast<lib::shape_t *>(body);
+    }
+
+    static const lib::shape_t *
+    from_chipmunk_const(const cpShape *body) TESTING_NOEXCEPT
+    {
+        return reinterpret_cast<const lib::shape_t *>(body);
+    }
+
     [[nodiscard]] float friction() TESTING_NOEXCEPT;
     void set_friction(float friction) TESTING_NOEXCEPT;
     [[nodiscard]] bool sensor() TESTING_NOEXCEPT;

--- a/src/thelib/space.cpp
+++ b/src/thelib/space.cpp
@@ -1,10 +1,16 @@
-#include "thelib/space.hpp"
+#include "space.hpp"
 #include <cassert>
 
 namespace lib {
 void space_t::add(body_t &body) TESTING_NOEXCEPT { body._add_to_space(this); }
-void space_t::add(shape_t &shape) TESTING_NOEXCEPT { shape._add_to_space(this); }
-void space_t::remove(body_t &body) TESTING_NOEXCEPT { cpSpaceRemoveBody(this, &body); }
+void space_t::add(shape_t &shape) TESTING_NOEXCEPT
+{
+    shape._add_to_space(this);
+}
+void space_t::remove(body_t &body) TESTING_NOEXCEPT
+{
+    cpSpaceRemoveBody(this, &body);
+}
 void space_t::remove(shape_t &shape) TESTING_NOEXCEPT
 {
     cpSpaceRemoveShape(this, &shape);
@@ -17,12 +23,18 @@ void space_t::remove(cpDampedSpring &constraint) TESTING_NOEXCEPT
 {
     remove(*(cpConstraint *)&constraint);
 }
-float space_t::damping() const TESTING_NOEXCEPT { return cpSpaceGetDamping(this); }
+float space_t::damping() const TESTING_NOEXCEPT
+{
+    return cpSpaceGetDamping(this);
+}
 void space_t::set_damping(float damping) TESTING_NOEXCEPT
 {
     cpSpaceSetDamping(this, damping);
 }
-vect_t space_t::gravity() const TESTING_NOEXCEPT { return cpSpaceGetGravity(this); }
+vect_t space_t::gravity() const TESTING_NOEXCEPT
+{
+    return cpSpaceGetGravity(this);
+}
 void space_t::set_gravity(vect_t gravity) TESTING_NOEXCEPT
 {
     cpSpaceSetGravity(this, gravity);
@@ -31,7 +43,8 @@ cpTimestamp space_t::collision_persistence() const TESTING_NOEXCEPT
 {
     return cpSpaceGetCollisionPersistence(this);
 }
-void space_t::set_collision_persistence(cpTimestamp persistence) TESTING_NOEXCEPT
+void space_t::set_collision_persistence(cpTimestamp persistence)
+    TESTING_NOEXCEPT
 {
     cpSpaceSetCollisionPersistence(this, persistence);
 }
@@ -67,7 +80,10 @@ float space_t::idle_speed_threshold() const TESTING_NOEXCEPT
 {
     return cpSpaceGetIdleSpeedThreshold(this);
 }
-int space_t::iterations() const TESTING_NOEXCEPT { return cpSpaceGetIterations(this); }
+int space_t::iterations() const TESTING_NOEXCEPT
+{
+    return cpSpaceGetIterations(this);
+}
 void space_t::set_iterations(int iterations) TESTING_NOEXCEPT
 {
     cpSpaceSetIterations(this, iterations);
@@ -87,5 +103,8 @@ float space_t::get_current_time_step() const TESTING_NOEXCEPT
     return cpSpaceGetCurrentTimeStep(this);
 }
 
-void space_t::step(float timestep) TESTING_NOEXCEPT { cpSpaceStep(this, timestep); }
+void space_t::step(float timestep) TESTING_NOEXCEPT
+{
+    cpSpaceStep(this, timestep);
+}
 } // namespace lib

--- a/src/thelib/space.hpp
+++ b/src/thelib/space.hpp
@@ -1,9 +1,9 @@
 #pragma once
+#include "body.hpp"
 #include "natural_log/natural_log.hpp"
+#include "shape.hpp"
 #include "testing/abort.hpp"
-#include "thelib/body.hpp"
-#include "thelib/shape.hpp"
-#include "thelib/vect.hpp"
+#include "vect.hpp"
 #include <chipmunk/chipmunk_structs.h>
 
 namespace lib {

--- a/src/thelib/space.hpp
+++ b/src/thelib/space.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "body.hpp"
+#include "collision_handler.hpp"
 #include "natural_log/natural_log.hpp"
 #include "shape.hpp"
 #include "testing/abort.hpp"
@@ -99,5 +100,79 @@ class space_t : public ::cpSpace
     [[nodiscard]] float get_sleep_time_threshold() const TESTING_NOEXCEPT;
     [[nodiscard]] body_t *get_static_body() const TESTING_NOEXCEPT;
     [[nodiscard]] float get_current_time_step() const TESTING_NOEXCEPT;
+
+    /// Add a collision handler which triggers whenever a certain two kinds of
+    /// shape collide.
+    ///
+    /// begin_func: function that gets called when two shapes of the given types
+    /// *start* colliding. Returning false from this function will make it so
+    /// that those two shapes dont generate collisions with each other for this
+    /// collision. Once they separate, they may collide again, and beginFunc
+    /// will be called again.
+    ///
+    /// pre_solve_func: function that runs when two shapes overlap, but before
+    /// they have been resolved to be in the correct locations. So if typeA is a
+    /// wall and typeB is a ball, the ball will still be inside the wall when
+    /// this function gets called. You can return false from this function to
+    /// cancel the effects of the collision.
+    ///
+    /// post_solve_func: This is called after collision happens, so you'll get
+    /// information about the normal of the collision and the contact points and
+    /// all that good stuff. The ball would be outside of the wall at this
+    /// point.
+    ///
+    /// separate_func: Function that gets called whenever two bodies stop
+    /// colliding. According to chipmunk docs, it is guaranteed to always be
+    /// called in even amounts with the beginFunc.
+    template <typename CollisionHandler>
+    inline constexpr void
+    add_collision_handler(const CollisionHandler &handler) TESTING_NOEXCEPT
+    {
+        cpCollisionHandler *realhandler = nullptr;
+        if (handler.type_b) {
+            realhandler = cpSpaceAddCollisionHandler(this, handler.type_a,
+                                                     handler.type_b.value());
+        } else {
+            realhandler = cpSpaceAddWildcardHandler(this, handler.type_a);
+        }
+
+        realhandler->userData = handler.user_data;
+
+        if constexpr (CollisionHandler::functions.begin_func) {
+            realhandler->beginFunc = [](cpArbiter *arb, cpSpace *space,
+                                        cpDataPointer userData) -> cpBool {
+                return CollisionHandler::functions.begin_func(
+                    *reinterpret_cast<arbiter_t *>(arb),
+                    *reinterpret_cast<space_t *>(space), userData);
+            };
+        }
+
+        if constexpr (CollisionHandler::functions.pre_solve_func) {
+            realhandler->preSolveFunc = [](cpArbiter *arb, cpSpace *space,
+                                           cpDataPointer userData) -> cpBool {
+                return CollisionHandler::functions.pre_solve_func(
+                    *reinterpret_cast<arbiter_t *>(arb),
+                    *reinterpret_cast<space_t *>(space), userData);
+            };
+        }
+
+        if constexpr (CollisionHandler::functions.post_solve_func) {
+            realhandler->postSolveFunc = [](cpArbiter *arb, cpSpace *space,
+                                            cpDataPointer userData) {
+                CollisionHandler::functions.post_solve_func(
+                    *reinterpret_cast<arbiter_t *>(arb),
+                    *reinterpret_cast<space_t *>(space), userData);
+            };
+        }
+
+        if constexpr (CollisionHandler::functions.separate_func) {
+            realhandler->separateFunc = [](cpArbiter *arb, cpSpace *space,
+                                           cpDataPointer userData) {
+                CollisionHandler::functions.separate_func(
+                    *reinterpret_cast<arbiter_t *>(arb),
+                    *reinterpret_cast<space_t *>(space), userData);
+            };
+        }
+    }
 };
 } // namespace lib


### PR DESCRIPTION
Improve the usability of the c++ wrapper over the chipmunk library so fewer casts are necessary and you never have to deal with cpBody or cpShape directly.